### PR TITLE
Fix when unchecking button from category settings

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -9,7 +9,7 @@ function initializeWithApi(api) {
   Topic.reopen({
     @computed('archived', 'custom_fields.enable_sold_button')
     canTopicBeMarkedAsSold: function() {
-      const enable_sold_button = this.category_enable_sold_button;
+      const enable_sold_button = (this.category_enable_sold_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -19,7 +19,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_purchased_button')
     canTopicBeMarkedAsPurchased: function() {
-      const enable_purchased_button = this.category_enable_purchased_button;
+      const enable_purchased_button = (this.category_enable_purchased_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -29,7 +29,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_exchanged_button')
     canTopicBeMarkedAsExchanged: function() {
-      const enable_exchanged_button = this.category_enable_exchanged_button;
+      const enable_exchanged_button = (this.category_enable_exchanged_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -39,7 +39,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_cancelled_button')
     canTopicBeMarkedAsCancelled: function() {
-      const enable_cancelled_button = this.category_enable_cancelled_button;
+      const enable_cancelled_button = (this.category_enable_cancelled_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled


### PR DESCRIPTION
Taking a look to the values of every variable, for instance, under the function canTopicBeMarkedAsCancelled, I realized that the return statement was returning a misleading value.

Context:
- Enable the plugin and enable Sold and Cancelled buttons under some random category.
- Then try to uncheck Cancelled button from that category. You will see that the button Cancelled still appears.

The error comes from extend-topic-for-sold-button.js.es6, at the time of defining the variable ```const enable_cancelled_button``` (it affects to all of the buttons, but I will focus on this). The thing is that at the time of executing the return statement, all '&&' returns true, because enable_cancelled_button is a string (which its value is "false").

If more info about the logs is needed, please let me know.