### PR TITLE
Fix when unchecking button from category settings (v1.1)

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -9,7 +9,7 @@ function initializeWithApi(api) {
   Topic.reopen({
     @computed('archived', 'custom_fields.enable_sold_button')
     canTopicBeMarkedAsSold: function() {
-      const enable_sold_button = this.category_enable_sold_button;
+      const enable_sold_button = (this.category_enable_sold_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -19,7 +19,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_purchased_button')
     canTopicBeMarkedAsPurchased: function() {
-      const enable_purchased_button = this.category_enable_purchased_button;
+      const enable_purchased_button = (this.category_enable_purchased_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -29,7 +29,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_exchanged_button')
     canTopicBeMarkedAsExchanged: function() {
-      const enable_exchanged_button = this.category_enable_exchanged_button;
+      const enable_exchanged_button = (this.category_enable_exchanged_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -39,7 +39,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_cancelled_button')
     canTopicBeMarkedAsCancelled: function() {
-      const enable_cancelled_button = this.category_enable_cancelled_button;
+      const enable_cancelled_button = (this.category_enable_cancelled_button.toLowerCase() == "true");
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled

--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -9,7 +9,9 @@ function initializeWithApi(api) {
   Topic.reopen({
     @computed('archived', 'custom_fields.enable_sold_button')
     canTopicBeMarkedAsSold: function() {
-      const enable_sold_button = (this.category_enable_sold_button)?(this.category_enable_sold_button.toLowerCase() == "true"):false;
+      const enable_sold_button = (this.category_enable_sold_button)?
+                                 (this.category_enable_sold_button.toLowerCase() == "true"):
+                                 false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -19,7 +21,9 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_purchased_button')
     canTopicBeMarkedAsPurchased: function() {
-      const enable_purchased_button = (this.category_enable_purchased_button)?(this.category_enable_purchased_button.toLowerCase() == "true"):false;
+      const enable_purchased_button = (this.category_enable_purchased_button)?
+                                      (this.category_enable_purchased_button.toLowerCase() == "true"):
+                                      false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -29,7 +33,9 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_exchanged_button')
     canTopicBeMarkedAsExchanged: function() {
-      const enable_exchanged_button = (this.category_enable_exchanged_button)?(this.category_enable_exchanged_button.toLowerCase() == "true"):false;
+      const enable_exchanged_button = (this.category_enable_exchanged_button)?
+                                      (this.category_enable_exchanged_button.toLowerCase() == "true"):
+                                      false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -39,7 +45,9 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_cancelled_button')
     canTopicBeMarkedAsCancelled: function() {
-      const enable_cancelled_button = (this.category_enable_cancelled_button)?(this.category_enable_cancelled_button.toLowerCase() == "true"):false;
+      const enable_cancelled_button = (this.category_enable_cancelled_button)?
+                                      (this.category_enable_cancelled_button.toLowerCase() == "true"):
+                                      false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled

--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -9,7 +9,7 @@ function initializeWithApi(api) {
   Topic.reopen({
     @computed('archived', 'custom_fields.enable_sold_button')
     canTopicBeMarkedAsSold: function() {
-      const enable_sold_button = (this.category_enable_sold_button.toLowerCase() == "true");
+      const enable_sold_button = (this.category_enable_sold_button)?(this.category_enable_sold_button.toLowerCase() == "true"):false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -19,7 +19,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_purchased_button')
     canTopicBeMarkedAsPurchased: function() {
-      const enable_purchased_button = (this.category_enable_purchased_button.toLowerCase() == "true");
+      const enable_purchased_button = (this.category_enable_purchased_button)?(this.category_enable_purchased_button.toLowerCase() == "true"):false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -29,7 +29,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_exchanged_button')
     canTopicBeMarkedAsExchanged: function() {
-      const enable_exchanged_button = (this.category_enable_exchanged_button.toLowerCase() == "true");
+      const enable_exchanged_button = (this.category_enable_exchanged_button)?(this.category_enable_exchanged_button.toLowerCase() == "true"):false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled
@@ -39,7 +39,7 @@ function initializeWithApi(api) {
 
     @computed('archived', 'custom_fields.enable_cancelled_button')
     canTopicBeMarkedAsCancelled: function() {
-      const enable_cancelled_button = (this.category_enable_cancelled_button.toLowerCase() == "true");
+      const enable_cancelled_button = (this.category_enable_cancelled_button)?(this.category_enable_cancelled_button.toLowerCase() == "true"):false;
       return !this.isPrivatemessage
         && currentUser && currentUser.id === this.user_id
         && this.siteSettings.topic_trade_buttons_enabled

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   js:
     topic_trading:
       enable_sold_button: Habilitar botón de 'Vendido'

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1,0 +1,19 @@
+en:
+  js:
+    topic_trading:
+      enable_sold_button: Habilitar botón de 'Vendido'
+      enable_purchased_button: Habilitar botón de 'Adquirido'
+      enable_exchanged_button: Habilitar botón de 'Cambiado'
+      enable_cancelled_button: Habilitar boton de 'Cancelado'
+      sold: Vendido
+      purchased: Adquirido
+      exchanged: Cambiado
+      cancelled: Cancelado
+      error_while_marked_as_sold: Error al marcar el tema como 'Vendido'
+      error_while_marked_as_purchased: Error al marcar el tema como 'Adquirido'
+      error_while_marked_as_exchanged: Error al marcar el tema como 'Cambiado'
+      error_while_marked_as_cancelled: Error al marcar el tema como 'Cancelado'
+      mark_as_sold_confirm: ¿Estás seguro de que quieres marcar el tema como 'Vendido'?
+      mark_as_purchased_confirm: ¿Estás seguro de que quieres marcar el tema como 'Adquirido'?
+      mark_as_exchanged_confirm: ¿Estás seguro de que quieres marcar el tema como 'Cambiado'?
+      mark_as_cancelled_confirm: ¿Estás seguro de que quieres marcar el tema como 'Cancelado'?

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   site_settings:
     topic_trade_buttons_enabled: "¿Habilitar botones de compraventa para los temas?"
   topic_trading:

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -1,0 +1,8 @@
+en:
+  site_settings:
+    topic_trade_buttons_enabled: "¿Habilitar botones de compraventa para los temas?"
+  topic_trading:
+    sold: Vendido
+    purchased: Adquirido
+    exchanged: Cambiado
+    cancelled: Cancelado


### PR DESCRIPTION
Taking a look to the values of every variable, for instance, under the function canTopicBeMarkedAsCancelled, I realized that the return statement was returning a misleading value.

Context:
- Enable the plugin and enable Sold and Cancelled buttons under some random category.
- Then try to uncheck Cancelled button from that category. You will see that the button Cancelled still appears.

The error comes from extend-topic-for-sold-button.js.es6, at the time of defining the variable ```const enable_cancelled_button``` (it affects to all of the buttons, but I will focus on this). The thing is that at the time of executing the return statement, all '&&' returns true, because enable_cancelled_button is a string (which its value is "false").

However, if none buttons are enabled after enabling the plugin, the value of ```this.category_enable_X_button``` is ```undefined```, that's why it requires a previous check.

Also, I took the trouble of adding the spanish translation of the buttons :-) .