### PR TITLE
Fix: Could not find module error after update Ember CLI

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -1,6 +1,6 @@
 import Topic from 'discourse/models/topic';
 import { withPluginApi } from 'discourse/lib/plugin-api';
-import computed from 'ember-addons/ember-computed-decorators';
+import computed from 'discourse-common/utils/decorators';
 
 function initializeWithApi(api) {
 

--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-topic-trade-buttons.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-topic-trade-buttons.js.es6
@@ -1,4 +1,4 @@
-import property from 'ember-addons/ember-computed-decorators';
+import property from 'discourse-common/utils/decorators';
 import Category from 'discourse/models/category';
 
 export default {


### PR DESCRIPTION
This PR fix this Error: Could not find module `ember-addons/ember-computed-decorators`.

![Screenshot 2021-11-08 at 22 32 50](https://user-images.githubusercontent.com/71207900/154037019-3236a77f-9c0e-4fd2-a71d-02b62347d94d.png)
This error is from a deprecation warning which became an error after update Ember CLI.

Thanks 🙂 