### PR TITLE
DEV: Resolve deprecations

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
+++ b/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
@@ -1,12 +1,15 @@
 import { popupAjaxError } from 'discourse/lib/ajax-error';
 import Topic from 'discourse/models/topic';
 import { ajax } from 'discourse/lib/ajax';
+import { getOwner } from "@ember/application";
 
 export default {
   actions: {
     clickSoldButton(topic) {
-      return bootbox.confirm(I18n.t('topic_trading.mark_as_sold_confirm'), I18n.t('no_value'), I18n.t('yes_value'), result => {
-        if (result) {
+      const dialog = getOwner(this).lookup("service:dialog");
+      return dialog.yesNoConfirm({
+        message: I18n.t('topic_trading.mark_as_sold_confirm'),
+        didConfirm: () => {
           ajax("/topic/sold", {
             type: "PUT",
             data: {
@@ -18,15 +21,19 @@ export default {
             topic.set('fancy_title', result.topic.fancy_title);
             topic.set('archived', result.topic.archived);
           }).catch(() => {
-            bootbox.alert(I18n.t('topic_trading.error_while_marked_as_sold'));
-          });
-        }
+            dialog.alert({
+              message: I18n.t('topic_trading.error_while_marked_as_sold')
+            });
+          })
+        },
       });
     },
 
     clickPurchasedButton(topic) {
-      return bootbox.confirm(I18n.t('topic_trading.mark_as_purchased_confirm'), I18n.t('no_value'), I18n.t('yes_value'), result => {
-        if (result) {
+      const dialog = getOwner(this).lookup("service:dialog");
+      return dialog.yesNoConfirm({
+        message: I18n.t('topic_trading.mark_as_purchased_confirm'),
+        didConfirm: () => {
           ajax("/topic/purchased", {
             type: "PUT",
             data: {
@@ -38,15 +45,19 @@ export default {
             topic.set('fancy_title', result.topic.fancy_title);
             topic.set('archived', result.topic.archived);
           }).catch(() => {
-            bootbox.alert(I18n.t('topic_trading.error_while_marked_as_purchased'));
-          });
-        }
+            dialog.alert({
+              message: I18n.t('topic_trading.error_while_marked_as_purchased')
+            });
+          })
+        },
       });
     },
 
     clickExchangedButton(topic) {
-      return bootbox.confirm(I18n.t('topic_trading.mark_as_exchanged_confirm'), I18n.t('no_value'), I18n.t('yes_value'), result => {
-        if (result) {
+      const dialog = getOwner(this).lookup("service:dialog");
+      return dialog.yesNoConfirm({
+        message: I18n.t('topic_trading.mark_as_exchanged_confirm'),
+        didConfirm: () => {
           ajax("/topic/exchanged", {
             type: "PUT",
             data: {
@@ -58,15 +69,19 @@ export default {
             topic.set('fancy_title', result.topic.fancy_title);
             topic.set('archived', result.topic.archived);
           }).catch(() => {
-            bootbox.alert(I18n.t('topic_trading.error_while_marked_as_exchanged'));
-          });
-        }
+            dialog.alert({
+              message: I18n.t('topic_trading.error_while_marked_as_exchanged')
+            });
+          })
+        },
       });
     },
 
     clickCancelledButton(topic) {
-      return bootbox.confirm(I18n.t('topic_trading.mark_as_cancelled_confirm'), I18n.t('no_value'), I18n.t('yes_value'), result => {
-        if (result) {
+      const dialog = getOwner(this).lookup("service:dialog");
+      return dialog.yesNoConfirm({
+        message: I18n.t('topic_trading.mark_as_cancelled_confirm'),
+        didConfirm: () => {
           ajax("/topic/cancelled", {
             type: "PUT",
             data: {
@@ -78,11 +93,12 @@ export default {
             topic.set('fancy_title', result.topic.fancy_title);
             topic.set('archived', result.topic.archived);
           }).catch(() => {
-            bootbox.alert(I18n.t('topic_trading.error_while_marked_as_cancelled'));
-          });
-        }
+            dialog.alert({
+              message: I18n.t('topic_trading.error_while_marked_as_cancelled')
+            });
+          })
+        },
       });
     }
-
   }
 };

--- a/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
+++ b/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
@@ -2,6 +2,7 @@ import { popupAjaxError } from 'discourse/lib/ajax-error';
 import Topic from 'discourse/models/topic';
 import { ajax } from 'discourse/lib/ajax';
 import { getOwner } from "@ember/application";
+import I18n from "discourse-i18n";
 
 export default {
   actions: {

--- a/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/trade-buttons.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/trade-buttons.hbs
@@ -1,12 +1,12 @@
 {{#if model.canTopicBeMarkedAsSold }}
-  {{d-button class="btn btn-primary" action="clickSoldButton" actionParam=model label="topic_trading.sold"}}
+  <DButton @class="btn btn-primary" @action={{action "clickSoldButton"}} @actionParam={{model}} @label="topic_trading.sold" />
 {{/if}}
 {{#if model.canTopicBeMarkedAsPurchased}}
-  {{d-button class="btn btn-primary" action="clickPurchasedButton" actionParam=model label="topic_trading.purchased"}}
+  <DButton @class="btn btn-primary" @action={{action "clickPurchasedButton"}} @actionParam={{model}} @label="topic_trading.purchased" />
 {{/if}}
 {{#if model.canTopicBeMarkedAsExchanged}}
-  {{d-button class="btn btn-primary" action="clickExchangedButton" actionParam=model label="topic_trading.exchanged"}}
+  <DButton @class="btn btn-primary" @action={{action "clickExchangedButton"}} @actionParam={{model}} @label="topic_trading.exchanged"/>
 {{/if}}
 {{#if model.canTopicBeMarkedAsCancelled}}
-  {{d-button class="btn" action="clickCancelledButton" actionParam=model label="topic_trading.cancelled"}}
+  <DButton @class="btn" @action={{action "clickCancelledButton"}} @actionParam={{model}} @label="topic_trading.cancelled" />
 {{/if}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,23 +11,23 @@ after_initialize do
 
   if SiteSetting.topic_trade_buttons_enabled then
 
-    add_to_serializer(:topic_view, :category_enable_sold_button, false) {
+    add_to_serializer(:topic_view, :category_enable_sold_button, respect_plugin_enabled: false) {
       object.topic.category.custom_fields['enable_sold_button'] if object.topic.category
     }
 
-    add_to_serializer(:topic_view, :category_enable_purchased_button, false) {
+    add_to_serializer(:topic_view, :category_enable_purchased_button, respect_plugin_enabled: false) {
       object.topic.category.custom_fields['enable_purchased_button'] if object.topic.category
     }
 
-    add_to_serializer(:topic_view, :category_enable_exchanged_button, false) {
+    add_to_serializer(:topic_view, :category_enable_exchanged_button, respect_plugin_enabled: false) {
       object.topic.category.custom_fields['enable_exchanged_button'] if object.topic.category
     }
 
-    add_to_serializer(:topic_view, :category_enable_cancelled_button, false) {
+    add_to_serializer(:topic_view, :category_enable_cancelled_button, respect_plugin_enabled: false) {
       object.topic.category.custom_fields['enable_cancelled_button'] if object.topic.category
     }
 
-    add_to_serializer(:topic_view, :custom_fields, false) {
+    add_to_serializer(:topic_view, :custom_fields, respect_plugin_enabled: false) {
       object.topic.custom_fields
     }
 


### PR DESCRIPTION
This fixes all the deprecation warnings.

* `add_to_seralizer` 's `respect_plugin_enabled` argument should be passed as a keyword argument
* The old jquery `bootbox` is replaced with `dialog`
* Uses angle bracket syntax

I will make another PR to lint everything after this one is merged.