### PR TITLE
Custom field and serialization fixes

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
+++ b/assets/javascripts/discourse/connectors/topic-above-post-stream/trade-buttons.js.es6
@@ -16,7 +16,6 @@ export default {
             },
           })
             .then((result) => {
-              topic.set("custom_fields.sold_at", result.topic.sold_at);
               topic.set("title", result.topic.title);
               topic.set("fancy_title", result.topic.fancy_title);
               topic.set("archived", result.topic.archived);
@@ -42,10 +41,6 @@ export default {
             },
           })
             .then((result) => {
-              topic.set(
-                "custom_fields.purchased_at",
-                result.topic.purchased_at
-              );
               topic.set("title", result.topic.title);
               topic.set("fancy_title", result.topic.fancy_title);
               topic.set("archived", result.topic.archived);
@@ -73,10 +68,6 @@ export default {
             },
           })
             .then((result) => {
-              topic.set(
-                "custom_fields.exchanged_at",
-                result.topic.exchanged_at
-              );
               topic.set("title", result.topic.title);
               topic.set("fancy_title", result.topic.fancy_title);
               topic.set("archived", result.topic.archived);
@@ -104,10 +95,6 @@ export default {
             },
           })
             .then((result) => {
-              topic.set(
-                "custom_fields.cancelled_at",
-                result.topic.cancelled_at
-              );
               topic.set("title", result.topic.title);
               topic.set("fancy_title", result.topic.fancy_title);
               topic.set("archived", result.topic.archived);

--- a/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-topic-for-sold-button.js.es6
@@ -6,7 +6,7 @@ function initializeWithApi(api) {
   const currentUser = api.getCurrentUser();
 
   Topic.reopen({
-    @computed("archived", "custom_fields.enable_sold_button")
+    @computed("archived")
     canTopicBeMarkedAsSold: function () {
       const enable_sold_button = this.category_enable_sold_button
         ? this.category_enable_sold_button.toLowerCase() === "true"
@@ -21,7 +21,7 @@ function initializeWithApi(api) {
       );
     },
 
-    @computed("archived", "custom_fields.enable_purchased_button")
+    @computed("archived")
     canTopicBeMarkedAsPurchased: function () {
       const enable_purchased_button = this.category_enable_purchased_button
         ? this.category_enable_purchased_button.toLowerCase() === "true"
@@ -36,7 +36,7 @@ function initializeWithApi(api) {
       );
     },
 
-    @computed("archived", "custom_fields.enable_exchanged_button")
+    @computed("archived")
     canTopicBeMarkedAsExchanged: function () {
       const enable_exchanged_button = this.category_enable_exchanged_button
         ? this.category_enable_exchanged_button.toLowerCase() === "true"
@@ -51,7 +51,7 @@ function initializeWithApi(api) {
       );
     },
 
-    @computed("archived", "custom_fields.enable_cancelled_button")
+    @computed("archived")
     canTopicBeMarkedAsCancelled: function () {
       const enable_cancelled_button = this.category_enable_cancelled_button
         ? this.category_enable_cancelled_button.toLowerCase() === "true"

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,19 +10,19 @@ PLUGIN_NAME ||= "discourse_topic_trade_buttons".freeze
 
 after_initialize do
   add_to_serializer(:topic_view, :category_enable_sold_button, include_condition: -> { object.topic.category }) do
-    object.topic.category.custom_fields["enable_sold_button"] if object.topic.category
+    object.topic.category.custom_fields["enable_sold_button"]
   end
 
   add_to_serializer(:topic_view, :category_enable_purchased_button, include_condition: -> { object.topic.category }) do
-    object.topic.category.custom_fields["enable_purchased_button"] if object.topic.category
+    object.topic.category.custom_fields["enable_purchased_button"]
   end
 
   add_to_serializer(:topic_view, :category_enable_exchanged_button, include_condition: -> { object.topic.category }) do
-    object.topic.category.custom_fields["enable_exchanged_button"] if object.topic.category
+    object.topic.category.custom_fields["enable_exchanged_button"]
   end
 
   add_to_serializer(:topic_view, :category_enable_cancelled_button, include_condition: -> { object.topic.category }) do
-    object.topic.category.custom_fields["enable_cancelled_button"] if object.topic.category
+    object.topic.category.custom_fields["enable_cancelled_button"]
   end
 
   add_to_serializer(:topic_view, :custom_fields, include_condition: -> { object.topic.category && scope.user&.admin? }) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,7 +32,7 @@ after_initialize do
       respect_plugin_enabled: false,
     ) { object.topic.category.custom_fields["enable_cancelled_button"] if object.topic.category }
 
-    add_to_serializer(:topic_view, :custom_fields, respect_plugin_enabled: false) do
+    add_to_serializer(:topic_view, :custom_fields, include_condition: -> { object.topic.category && scope.user&.admin? }) do
       object.topic.custom_fields
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,32 +9,24 @@ enabled_site_setting :topic_trade_buttons_enabled
 PLUGIN_NAME ||= "discourse_topic_trade_buttons".freeze
 
 after_initialize do
-  if SiteSetting.topic_trade_buttons_enabled
-    add_to_serializer(:topic_view, :category_enable_sold_button, respect_plugin_enabled: false) do
-      object.topic.category.custom_fields["enable_sold_button"] if object.topic.category
-    end
+  add_to_serializer(:topic_view, :category_enable_sold_button, include_condition: -> { object.topic.category }) do
+    object.topic.category.custom_fields["enable_sold_button"] if object.topic.category
+  end
 
-    add_to_serializer(
-      :topic_view,
-      :category_enable_purchased_button,
-      respect_plugin_enabled: false,
-    ) { object.topic.category.custom_fields["enable_purchased_button"] if object.topic.category }
+  add_to_serializer(:topic_view, :category_enable_purchased_button, include_condition: -> { object.topic.category }) do
+    object.topic.category.custom_fields["enable_purchased_button"] if object.topic.category
+  end
 
-    add_to_serializer(
-      :topic_view,
-      :category_enable_exchanged_button,
-      respect_plugin_enabled: false,
-    ) { object.topic.category.custom_fields["enable_exchanged_button"] if object.topic.category }
+  add_to_serializer(:topic_view, :category_enable_exchanged_button, include_condition: -> { object.topic.category }) do
+    object.topic.category.custom_fields["enable_exchanged_button"] if object.topic.category
+  end
 
-    add_to_serializer(
-      :topic_view,
-      :category_enable_cancelled_button,
-      respect_plugin_enabled: false,
-    ) { object.topic.category.custom_fields["enable_cancelled_button"] if object.topic.category }
+  add_to_serializer(:topic_view, :category_enable_cancelled_button, include_condition: -> { object.topic.category }) do
+    object.topic.category.custom_fields["enable_cancelled_button"] if object.topic.category
+  end
 
-    add_to_serializer(:topic_view, :custom_fields, include_condition: -> { object.topic.category && scope.user&.admin? }) do
-      object.topic.custom_fields
-    end
+  add_to_serializer(:topic_view, :custom_fields, include_condition: -> { object.topic.category && scope.user&.admin? }) do
+    object.topic.custom_fields
   end
 
   module ::DiscourseTopicTradeButtons


### PR DESCRIPTION
### Security fix: information leakage

All custom fields (including those from other plugins!) are being serialized, including to anonymous users. Custom fields can contain sensitive data and should never be serialized like that. Since the `sold_at` etc values are being set server side anyway and the buttons are "computed" on `topic.archived`, the custom field logic can be removed from the frontend user-facing code and the custom fields only need to be serialized for the admin interface to work - hence the serialization can be limited to admin users. We do suspect that this is not even necessary either. 

### Initialization fixes

The `  if SiteSetting.topic_trade_buttons_enabled` check that is fencing the serialization logic makes it necessary to restart Discourse after enabling or disabling the plugin. This check is unnecessary since Discourse already takes care of that.
Using `respect_plugin_enabled: false` is unnecessary and aggravates the security issue described above.
